### PR TITLE
hypr: Fix problem with multiple dialog apps

### DIFF
--- a/hypr/hyprland.conf
+++ b/hypr/hyprland.conf
@@ -33,6 +33,7 @@ exec-once = emacs --bg-daemon
 input {
     kb_layout = us
     follow_mouse = 1
+    focus_on_close = 1
     float_switch_override_focus = 2
     sensitivity = 0 # -1.0 - 1.0, 0 means no modification.
 }


### PR DESCRIPTION
Had a problem with apps like Freeplane and Gramps where if multiple dialogs were opened, closing one would not return focus to the spawning window. So far this seems to fix it.